### PR TITLE
chore(ci): bump dependabot/fetch-metadata to v3

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v1.1.1
+        uses: dependabot/fetch-metadata@v3
         with:
           github-token: "${{ secrets.AUTOMERGE_TOKEN }}"
       - name: Approve a PR


### PR DESCRIPTION
## Summary
- Bumps `dependabot/fetch-metadata` from `v1.1.1` to `v3` in the auto-merge workflow.
- `v1.1.1` ran on the deprecated Node 20 runtime, emitting a deprecation warning on every auto-merge run. `v3` runs on Node 24 and clears the warning.

## Test plan
- [ ] CI passes on this PR.
- [ ] On the next Dependabot PR, confirm the "Dependabot metadata" step runs without the Node 20 deprecation warning and auto-merge still approves + merges.