### PR TITLE
chore(deps): fix moderate js-yaml DoS (GHSA-h67p-54hq-rp68)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1291,9 +1291,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12324,7 +12324,7 @@
         "camelcase": "^5.3.1",
         "find-up": "^4.1.0",
         "get-package-type": "^0.1.0",
-        "js-yaml": "^3.13.1",
+        "js-yaml": "3.15.0",
         "resolve-from": "^5.0.0"
       },
       "dependencies": {
@@ -12348,9 +12348,9 @@
           }
         },
         "js-yaml": {
-          "version": "3.14.2",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-          "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+          "version": "3.15.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+          "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
           "dev": true,
           "requires": {
             "argparse": "^1.0.7",

--- a/package.json
+++ b/package.json
@@ -79,6 +79,9 @@
   "overrides": {
     "minimist": "1.2.6",
     "lodash": "4.18.0",
-    "tmp": "0.2.7"
+    "tmp": "0.2.7",
+    "@istanbuljs/load-nyc-config": {
+      "js-yaml": "3.15.0"
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Resolves the moderate Dependabot advisory [GHSA-h67p-54hq-rp68](https://github.com/advisories/GHSA-h67p-54hq-rp68) — quadratic-complexity DoS in js-yaml `<3.15.0` merge-key handling.
- The vulnerable `js-yaml@3.14.x` is pulled in transitively only through the coverage tooling (`ts-jest` → `@jest/transform` → `babel-plugin-istanbul` → `@istanbuljs/load-nyc-config`).
- Adds a **scoped** `overrides` entry pinning `js-yaml` to `3.15.0` (last 3.x release) under that path, so the `js-yaml@4.x` used by eslint/commitlint is left untouched.
- `npm audit` now reports **0 vulnerabilities**; test suite passes.

## Test plan
- [ ] CI passes.
- [ ] `npm audit` reports 0 vulnerabilities.
- [ ] `npm ls js-yaml` shows `3.15.0 overridden` only under `@istanbuljs/load-nyc-config`, with 4.x retained elsewhere.